### PR TITLE
Several improvements and fixes

### DIFF
--- a/discord_key_bot/keyparse/__init__.py
+++ b/discord_key_bot/keyparse/__init__.py
@@ -11,12 +11,23 @@ keyspace = {
     ],
     "playstation": [r"^[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}$"],
     "origin": [
-        r"^[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}$"
+        r"^[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}$"
     ],
     "uplay": [
         r"^[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}$",
         r"^[a-z,A-Z,0-9]{3}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}-[a-z,A-Z,0-9]{4}$",
     ],
+    "switch": [r"^[a-z,A-Z,0-9]{16}$"],
+    "xbox": [r"^[a-z,A-Z,0-9]{25}$"],
+}
+
+examples = {
+    "GOG": ["AAAAA-BBBBB-CCCCC-DDDDD", "ABCDEABCDEABCDEABC (18 chars)"],
+    "Steam": ["AAAAA-BBBBB-CCCCC", "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE"],
+    "Playstation": ["AAAA-BBBB-CCCC"],
+    "Origin": ["AAAA-BBBB-CCCC-DDDD"],
+    "Switch": ["ABCDABCDABCDABCD (16 chars)"],
+    "Xbox": ["ABCDEABCDEABCDEABCDEABCDE (25 chars)"],
 }
 
 _compiled = {k: [re.compile(r) for r in v] for k, v in keyspace.items()}


### PR DESCRIPTION
Features:
- Added support for Xbox and Switch keys
- Added `platforms` command to show valid platforms as well as example key formats
- When a command fails, display a message pointing to `help {command}` instead of silently failing
- Added `random` command to show a random selection of games
- Added ability to restrict bot responses to a single channel (`help` still works everywhere, so it can still work in DMs)
- After `share` and `unshare` commands, the message now includes the total number of games shared with the server

Fixes:
- Help messages will use the appropriate command prefix
- `claim` will accept any casing of the platform name
- `browse` and `platform` now sort case insensitive