### PR TITLE
Always flush when renaming games, fix delete command's help text

### DIFF
--- a/discord_key_bot/command/admin.py
+++ b/discord_key_bot/command/admin.py
@@ -222,8 +222,8 @@ class AdminCommands(commands.Cog, name='Admin Commands', command_attrs=dict(hidd
                 session.flush()
 
                 session.delete(game)
-                session.flush()
 
+            session.flush()
             session.commit()
 
     @commands.command()
@@ -334,7 +334,7 @@ class AdminCommands(commands.Cog, name='Admin Commands', command_attrs=dict(hidd
             kind=inspect.Parameter.POSITIONAL_ONLY,
         )
     ):
-        """Purge expired keys and orphaned games"""
+        """Delete a game and all associated keys"""
 
         self.logger.info(f"delete request from user {ctx.author.display_name} for game_id {game_id}")
 


### PR DESCRIPTION
Always flush when renaming a game, fix delete admin command help text.